### PR TITLE
読者の声の下線の位置をPCとスマホで切り替える

### DIFF
--- a/styles/utils.module.css
+++ b/styles/utils.module.css
@@ -147,7 +147,12 @@
 .voiceSummary {
   font-weight: bold;
   border-bottom: 0.5rem solid red;
-  padding: 10px 1rem;
+}
+
+@media (min-width: 768px) {
+  .voiceSummary {
+    padding: 10px 1rem;
+  }
 }
 
 .small {


### PR DESCRIPTION
(突然のPRで恐縮です。もしPRを受け付けていなかったら、反応は不要です。それかCloseしてしまってください)

* 読者の声の下線の位置が、スマホで表示した時に次の行の文字と被ってしまっていたようなので、メディアクエリでpaddingの付与を分岐するようにしてみました。
* `npm run export` はお任せした方が良さそうと思いましたので、ここでは行っていないです。

## スクリーンショット

PC版の幅はiPad Air (820px)
SP版の幅はiPhone XR (414px)

をもとに検証を行っています。(いずれもGoogle Chromeです)

### PC版 (Before / Afterで差分なし)

![スクリーンショット 2022-05-11 20 42 13](https://user-images.githubusercontent.com/6882878/167843288-4eecede7-1212-4a75-9b24-14c076ad81b1.png)

### SP版 Before

![スクリーンショット 2022-05-11 20 43 40](https://user-images.githubusercontent.com/6882878/167843333-e58df99e-0271-4e72-b2db-67c22d3e192f.png)

### SP版 After

![スクリーンショット 2022-05-11 20 42 26](https://user-images.githubusercontent.com/6882878/167843442-2ad1e370-dbb1-486c-948d-68b197a6d18e.png)

